### PR TITLE
fix Issue: jaroWinkler gives score > 1 for distinct strings

### DIFF
--- a/src/metrics/distance/jaro-winkler.js
+++ b/src/metrics/distance/jaro-winkler.js
@@ -61,7 +61,7 @@ function customJaroWinkler(options, a, b) {
   if (j < boostThreshold)
     return j;
 
-  return j + Math.min(scalingFactor, maxLength) * prefix * (1 - j);
+  return j + Math.min(scalingFactor, 1 / maxLength) * prefix * (1 - j);
 }
 
 /**

--- a/test/metrics/distance/jaro-winkler.js
+++ b/test/metrics/distance/jaro-winkler.js
@@ -40,7 +40,8 @@ describe('jaro-winkler', function() {
       ['Dwayne'.split(''), 'Duane'.split(''), 0.84],
       ['Martha', 'Marhta', 0.96],
       ['Dixon', 'Dicksonx', 0.81],
-      ['Duane', 'Freakishlylongstring', 0.47]
+      ['Duane', 'Freakishlylongstring', 0.47],
+      ['commonlongprefixword', 'commonlongprefixworm', 0.9983]
     ];
 
     tests.forEach(function([a, b, d]) {


### PR DESCRIPTION
Bug: distinct strings with common prefixes get a weight > 1.0
jaroWinkler('commonlongprefixword', 'commonlongprefixworm')

The former code easily gives weights > 1.0 for distinct strings. 