### PR TITLE
moving ngrams doc page under tokenizers to reflect move in version 0.15.0

### DIFF
--- a/index.md
+++ b/index.md
@@ -144,7 +144,6 @@ The library's source code can be found on its Github [repository]({{ site.url }}
         <li>&middot; <em><a href="{{ site.baseurl }}/stats/descriptive">descriptive</a></em></li>
         <li>&middot; <em><a href="{{ site.baseurl }}/stats/frequencies">frequencies</a></em></li>
         <li>&middot; <em><a href="{{ site.baseurl }}/stats/inferential">inferential</a></em></li>
-        <li>&middot; <em><a href="{{ site.baseurl }}/stats/ngrams">ngrams</a></em></li>
       </ul>
     </li>
     <li id="stemmers">
@@ -195,6 +194,12 @@ The library's source code can be found on its Github [repository]({{ site.url }}
           <a href="{{ site.baseurl }}/tokenizers/lines">lines</a>
           <ul>
             <li>&middot; <em><a href="{{ site.baseurl }}/tokenizers/lines#naive">naive</a></em></li>
+          </ul>
+        </li>
+        <li>
+          <a href="{{ site.baseurl }}/tokenizers/ngrams">ngrams</a>
+          <ul>
+            <li>&middot; <em><a href="{{ site.baseurl }}/tokenizers/ngrams">ngrams</a></em></li>
           </ul>
         </li>
         <li>

--- a/tokenizers/ngrams.md
+++ b/tokenizers/ngrams.md
@@ -8,7 +8,7 @@ title: Ngrams
 </span>
 
 
-The `stats/ngrams` module gather functions used to compute ngrams from the given sequences.
+The `tokenizers/ngrams` module gather functions used to compute ngrams from the given sequences.
 
 n-grams are a sequence's subsequences of size n.
 

--- a/tokenizers/ngrams.md
+++ b/tokenizers/ngrams.md
@@ -13,13 +13,13 @@ The `tokenizers/ngrams` module gather functions used to compute ngrams from the 
 n-grams are a sequence's subsequences of size n.
 
 ```js
-import ngrams from 'talisman/stats/ngrams';
+import ngrams from 'talisman/tokenizers/ngrams';
 // Alternatively, you can use these convenient shortcuts
 import {
   bigrams,
   trigrams,
   quadrigrams
-} from 'talisman/stats/ngrams';
+} from 'talisman/tokenizers/ngrams';
 
 ngrams(2, ['The', 'cat', 'is', 'happy']);
 >>> [


### PR DESCRIPTION
Just noticed that the docs don't reflect the change in  https://github.com/Yomguithereal/talisman/commit/63b0dd02ddd54507f6a4e390f019a01f2cc21fcb