### PR TITLE
Fixed regex for words containing "aine" in sonnex.js

### DIFF
--- a/src/phonetics/french/sonnex.js
+++ b/src/phonetics/french/sonnex.js
@@ -70,7 +70,7 @@ const RULES = {
     ['a', 'a'],
     ['aient', 'E'],
     ['ain', '1'],
-    [/ain(.)(.*)$/, (v, cs) => {
+    [/^ain(.)(.*)/, (v, cs) => {
       if (isVowel(v))
         return ['E', v + cs];
       return ['1', v + cs];


### PR DESCRIPTION
sonnex("capitaine") -> kE
Should be:
sonnex("capitaine") -> kapitEn